### PR TITLE
Add OTel profiling pipeline to collector config

### DIFF
--- a/config/otelcol/otelcol.yml
+++ b/config/otelcol/otelcol.yml
@@ -139,6 +139,13 @@ service:
       exporters:
         - elasticsearch/otel
         - debug
+    profiles/fromsdk:
+      receivers:
+        - otlp/fromsdk
+      processors: []
+      exporters:
+        - elasticsearch/otel
+        - debug
     # Send traces to APM server
     # traces/fromsdk:
     #   receivers:


### PR DESCRIPTION
## Summary
- Adds `profiles/fromsdk` pipeline to the OTel collector configuration
- Routes profiling data from the existing `otlp/fromsdk` receiver through to `elasticsearch/otel` and `debug` exporters
- No new receivers or ports needed — the OTLP receiver already accepts profiling signals

Closes #11

## Test plan
- [ ] `docker compose up` — verify otelcol starts without errors
- [ ] Send profiling data to `localhost:4317` or `localhost:4318` and verify it reaches Elasticsearch

🤖 Generated with [Claude Code](https://claude.com/claude-code)