### PR TITLE
Generate Kibana encryption keys on startup

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -25,6 +25,8 @@ configs:
     file: scripts/create-api-key.sh
   create-certs.sh:
     file: scripts/create-certs.sh
+  generate-kibana-keys.sh:
+    file: scripts/generate-kibana-keys.sh
   elasticsearch.yml:
     file: config/elasticsearch.yml
   kibana.yml:
@@ -107,23 +109,30 @@ services:
       - esdata:/usr/share/elasticsearch/data
       - eslogs:/usr/share/elasticsearch/logs
   kibana:
-    # TODO generate encryption keys
+    command: >
+      sh -c '
+        cp /usr/share/kibana/config/kibana.yml.base /usr/share/kibana/config/kibana.yml &&
+        cat /etc/elastic/kibana_encryption_keys.yml >> /usr/share/kibana/config/kibana.yml &&
+        /usr/local/bin/kibana-docker
+      '
     configs:
       - source: kibana.yml
-        target: /usr/share/kibana/config/kibana.yml
+        target: /usr/share/kibana/config/kibana.yml.base
       - source: node.options
         target: /usr/share/kibana/config/node.options
     container_name: kibana
     depends_on:
       elasticsearch:
         condition: service_healthy
+      setup_kibana_keys:
+        condition: service_completed_successfully
       setup_kibana_user:
         condition: service_completed_successfully
     develop:
       watch:
         - action: sync+restart
           path: config/kibana.yml
-          target: /usr/share/kibana/config/kibana.yml
+          target: /usr/share/kibana/config/kibana.yml.base
     environment:
       - ELASTICSEARCH_HOSTS=https://elasticsearch:${ES_PORT}
       - ELASTICSEARCH_PASSWORD=${ELASTIC_PASSWORD}
@@ -142,6 +151,7 @@ services:
     restart: unless-stopped
     volumes:
       - certs:/usr/share/kibana/config/certs
+      - etc:/etc/elastic
       - kibana_data:/usr/share/kibana/data
       - kibana_logs:/usr/share/kibana/logs
   otelcol:
@@ -243,6 +253,18 @@ services:
     command: bash bin/set-kibana-system-user-password.sh
     volumes:
       - certs:/usr/share/elasticsearch/config/certs
+  setup_kibana_keys:
+    command: bash /bin/generate-kibana-keys.sh
+    configs:
+      - mode: 0700
+        source: generate-kibana-keys.sh
+        target: /bin/generate-kibana-keys.sh
+    container_name: "setup_kibana_keys"
+    hostname: host.docker.internal
+    image: pnnlmiscscripts/curl-jq
+    user: "0"
+    volumes:
+      - etc:/etc/elastic
   setup_universal_profiling:
     scale: 0
     configs:

--- a/config/kibana.yml
+++ b/config/kibana.yml
@@ -222,10 +222,8 @@ uiSettings.overrides:
 feature_flags.overrides:
   discover.cascadeLayoutEnabled: true
 
-# Encryption settings
-xpack.encryptedSavedObjects.encryptionKey: 0c4fb61f013d771f43d321e5b2484f4d
-xpack.reporting.encryptionKey: 369ecfa55ee4b9e8c3d5481c6589287a
-xpack.security.encryptionKey: 944c9b01e335cf7eebcda4413797f494
+# Encryption keys are generated at startup by the setup_kibana_keys service
+# and appended to this config file. See scripts/generate-kibana-keys.sh.
 
 # Other xpack settings
 xpack.profiling.enabled: true

--- a/scripts/generate-kibana-keys.sh
+++ b/scripts/generate-kibana-keys.sh
@@ -9,9 +9,9 @@ if [ -f "$OUTPUT_FILE" ]; then
 fi
 
 # Generate three 32-character hex keys
-KEY1=$(cat /dev/urandom | tr -dc 'a-f0-9' | head -c 32)
-KEY2=$(cat /dev/urandom | tr -dc 'a-f0-9' | head -c 32)
-KEY3=$(cat /dev/urandom | tr -dc 'a-f0-9' | head -c 32)
+KEY1=$(dd if=/dev/urandom bs=16 count=1 2>/dev/null | xxd -p)
+KEY2=$(dd if=/dev/urandom bs=16 count=1 2>/dev/null | xxd -p)
+KEY3=$(dd if=/dev/urandom bs=16 count=1 2>/dev/null | xxd -p)
 
 cat > "$OUTPUT_FILE" <<EOF
 xpack.encryptedSavedObjects.encryptionKey: ${KEY1}

--- a/scripts/generate-kibana-keys.sh
+++ b/scripts/generate-kibana-keys.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+set -eo pipefail
+
+OUTPUT_FILE="/etc/elastic/kibana_encryption_keys.yml"
+
+if [ -f "$OUTPUT_FILE" ]; then
+    echo "Kibana encryption keys already exist at $OUTPUT_FILE, skipping." >&2
+    exit 0
+fi
+
+# Generate three 32-character hex keys
+KEY1=$(cat /dev/urandom | tr -dc 'a-f0-9' | head -c 32)
+KEY2=$(cat /dev/urandom | tr -dc 'a-f0-9' | head -c 32)
+KEY3=$(cat /dev/urandom | tr -dc 'a-f0-9' | head -c 32)
+
+cat > "$OUTPUT_FILE" <<EOF
+xpack.encryptedSavedObjects.encryptionKey: ${KEY1}
+xpack.reporting.encryptionKey: ${KEY2}
+xpack.security.encryptionKey: ${KEY3}
+EOF
+
+echo "Kibana encryption keys generated and written to $OUTPUT_FILE" >&2


### PR DESCRIPTION
## Summary
- Removes hardcoded encryption keys from `config/kibana.yml`
- Adds `scripts/generate-kibana-keys.sh` that generates three 32-character hex keys on first run
- Adds `setup_kibana_keys` service that runs before Kibana starts
- Generated keys persist on the `etc` Docker volume across restarts
- Kibana merges base config with generated keys at startup via command override

Closes #6

## Test plan
- [ ] `docker compose down -v && docker compose up` — verify Kibana starts successfully
- [ ] `docker compose logs setup_kibana_keys` — should show "Kibana encryption keys generated"
- [ ] `docker compose restart kibana` — should reuse existing keys (no regeneration)
- [ ] Verify encrypted saved objects work (e.g., create an alert rule)

🤖 Generated with [Claude Code](https://claude.com/claude-code)