### PR TITLE
Add AutoOps support as optional profile

### DIFF
--- a/.env
+++ b/.env
@@ -26,6 +26,16 @@ OTEL_COLLECTOR_PORT_GRPC=4317
 OTEL_COLLECTOR_PORT_HTTP=4318
 OTEL_EXPORTER_OTLP_ENDPOINT=otelcol:${OTEL_COLLECTOR_PORT_GRPC}
 
+# AutoOps (optional, use --profile autoops)
+AUTOOPS_IMAGE=docker.elastic.co/elastic-agent/elastic-otel-collector-wolfi:9.4.0-SNAPSHOT
+AUTOOPS_OTEL_URL=
+AUTOOPS_TOKEN=
+AUTOOPS_ES_URL=https://elasticsearch:9200
+ELASTIC_CLOUD_CONNECTED_MODE_API_KEY=
+AUTOOPS_ES_USERNAME=elastic
+AUTOOPS_ES_PASSWORD=$ELASTIC_PASSWORD
+AUTOOPS_TEMP_RESOURCE_ID=
+
 # Profiling
 PROFILING_COLLECTOR_IMAGE=docker.elastic.co/observability/profiling-collector:8.17.0
 PROFILING_AGENT_IMAGE=docker.elastic.co/observability/profiling-agent:9.4.0-SNAPSHOT

--- a/compose.yaml
+++ b/compose.yaml
@@ -263,6 +263,25 @@ services:
     command: bash bin/initialize-universal-profiling.sh
     volumes:
       - certs:/usr/share/elasticsearch/config/certs
+  autoops:
+    profiles: [autoops]
+    container_name: "autoops"
+    depends_on:
+      elasticsearch:
+        condition: service_healthy
+    environment:
+      - AUTOOPS_OTEL_URL
+      - AUTOOPS_TOKEN
+      - AUTOOPS_ES_URL
+      - ELASTIC_CLOUD_CONNECTED_MODE_API_KEY
+      - AUTOOPS_ES_USERNAME
+      - AUTOOPS_ES_PASSWORD
+      - AUTOOPS_TEMP_RESOURCE_ID
+    hostname: host.docker.internal
+    image: ${AUTOOPS_IMAGE}
+    restart: on-failure
+    volumes:
+      - certs:/usr/share/elastic-agent/config/certs
   profiling-collector:
     profiles: [profiling]
     image: ${PROFILING_COLLECTOR_IMAGE}


### PR DESCRIPTION
## Summary
- Adds `autoops` service behind `--profile autoops` using the `elastic-otel-collector-wolfi` image
- Adds placeholder environment variables in `.env` for cloud credentials (AUTOOPS_OTEL_URL, AUTOOPS_TOKEN, ELASTIC_CLOUD_CONNECTED_MODE_API_KEY, AUTOOPS_TEMP_RESOURCE_ID)
- Users supply their own Elastic Cloud credentials to enable AutoOps monitoring

Closes #12

## Test plan
- [ ] `docker compose --profile autoops config` — verify config is valid
- [ ] `docker compose --profile autoops up` — verify autoops container starts (will fail without credentials, which is expected)
- [ ] With valid credentials set in `.env`, verify AutoOps agent connects to Elastic Cloud

🤖 Generated with [Claude Code](https://claude.com/claude-code)